### PR TITLE
Fix Optional import in JwtAuthFilter

### DIFF
--- a/src/main/java/br/com/fiap/safecap/config/JwtAuthFilter.java
+++ b/src/main/java/br/com/fiap/safecap/config/JwtAuthFilter.java
@@ -2,6 +2,7 @@ package br.com.fiap.safecap.config;
 
 import br.com.fiap.safecap.util.JwtUtil;
 import br.com.fiap.safecap.service.UsuarioService;
+import br.com.fiap.safecap.model.Usuario;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
@@ -43,7 +45,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         userEmail = jwtUtil.getEmailFromToken(jwt);
 
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            java.util.Optional<br.com.fiap.safecap.model.Usuario> user = usuarioService.findByEmail(userEmail);
+            Optional<Usuario> user = usuarioService.findByEmail(userEmail);
             if (user.isPresent() && jwtUtil.validateToken(jwt)) {
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                         user.get(), null, null


### PR DESCRIPTION
## Summary
- update imports in `JwtAuthFilter`
- use `Optional<Usuario>` when fetching user

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684452be9d68832d972af90135e6513c